### PR TITLE
fix: make cards with specified width not resize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,8 +109,8 @@ export default class Carousel extends React.Component {
       return null;
     }
     return vertical ?
-      scrollerElement.offsetHeight / visibleItems :
-      scrollerElement.offsetWidth / visibleItems;
+      (scrollerElement.offsetHeight + gutter) / visibleItems :
+      (scrollerElement.offsetWidth + gutter) / visibleItems;
   }
 
   forceScrollUp() {

--- a/src/index.js
+++ b/src/index.js
@@ -84,22 +84,21 @@ export default class Carousel extends React.Component {
     this.computeNumToScroll();
     this.debouncedDimensionsUpdateFunction = debounce(() => {
       const { scroller: scrollerElement } = this.refs;
-      const { children, gutter, vertical, visibleItems } = this.props;
+      const { children, gutter, vertical, visibleItems, width } = this.props;
       const newListElementDimension = this.computeDimensions(
         scrollerElement,
         visibleItems,
         gutter,
         vertical
       );
-      if (newListElementDimension) {
+      if (newListElementDimension && !width) {
         const newListDimension = newListElementDimension * children.length;
         this.scroller.updateDimensions(newListDimension - gutter, scrollerElement.offsetHeight);
         this.setState({
           listElementDimension: newListElementDimension,
           listDimension: newListDimension,
         });
-        this.scrollWidth = this.props.width ? this.props.width * this.numOfItemsToScrollBy :
-          newListElementDimension * this.numOfItemsToScrollBy;
+        this.scrollWidth = newListElementDimension * this.numOfItemsToScrollBy;
       }
     }, this.debounceWait);
     return this.debouncedDimensionsUpdateFunction;
@@ -110,8 +109,8 @@ export default class Carousel extends React.Component {
       return null;
     }
     return vertical ?
-      (scrollerElement.offsetHeight + gutter) / visibleItems :
-      (scrollerElement.offsetWidth + gutter) / visibleItems;
+      scrollerElement.offsetHeight / visibleItems :
+      scrollerElement.offsetWidth / visibleItems;
   }
 
   forceScrollUp() {

--- a/test/index.js
+++ b/test/index.js
@@ -55,7 +55,7 @@ describe('Carousel', () => {
 
     it('computes the correct dimensions', () => {
       const carouselInstance = new Carousel();
-      carouselInstance.computeDimensions({ offsetWidth: 90 }, 4, 10, false).should.equal(22.5);
+      carouselInstance.computeDimensions({ offsetWidth: 90 }, 4, 10, false).should.equal(25);
     });
 
     it('displays the correct controls', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -55,7 +55,7 @@ describe('Carousel', () => {
 
     it('computes the correct dimensions', () => {
       const carouselInstance = new Carousel();
-      carouselInstance.computeDimensions({ offsetWidth: 90 }, 4, 10, false).should.equal(25);
+      carouselInstance.computeDimensions({ offsetWidth: 90 }, 4, 10, false).should.equal(22.5);
     });
 
     it('displays the correct controls', () => {


### PR DESCRIPTION
Currently cards were resizing even when a card width was specified which should not happen, this makes it not resize on window resize event when width is not specified.